### PR TITLE
Build: fixes build problem for m1 chip

### DIFF
--- a/docker-compose_example.yml
+++ b/docker-compose_example.yml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   web:
+    platform: linux/amd64
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Docker package "google-chrome-stable" is not available for m1. Adding platform refinement solves this problem. Poor performance or fail of image not detected.